### PR TITLE
changed require in ns form to keyword instead of symbol

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,7 +1,11 @@
 (set-env!
- :src-paths    #{"src"}
+ :source-paths #{"src"}
  :dependencies '[[adzerk/bootlaces "0.1.11" :scope "test"]
+                 [onetom/boot-lein-generate "0.1.3" :scope "test"]
                  [selmer "1.10.7"]])
+
+(require '[boot.lein])
+(boot.lein/generate)
 
 (require '[adzerk.bootlaces :refer :all])
 

--- a/src/bnadlerjr/boot_selmer.clj
+++ b/src/bnadlerjr/boot_selmer.clj
@@ -1,11 +1,11 @@
 (ns bnadlerjr.boot-selmer
   {:boot/export-tasks true}
-  (require [boot.core :as core]
-           [boot.util :as util]
-           [clojure.edn :as edn]
-           [clojure.java.io :as io]
-           [clojure.string :as s]
-           [selmer.parser :refer [render-file]]))
+  (:require [boot.core :as core]
+            [boot.util :as util]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as s]
+            [selmer.parser :refer [render-file]]))
 
 (defn- selmer->html
   [path]

--- a/src/bnadlerjr/boot_selmer.clj
+++ b/src/bnadlerjr/boot_selmer.clj
@@ -34,8 +34,17 @@
   underscore are considered to be partials loaded by the other files."
   [x context VAL str "Filename of .edn file that contains a context map that
                       will be injected into templates."
-   f filters VAL str "Filename of .edn file that contains a map of filter keywords to filter function symbols."]
+   f filters VAL str "Filename of .edn file that contains a map of filter keywords to filter function symbols."
+   c cache bool "Indicate whether selmer should cache compiled templates. Defaults to true."]
   (let [tmp (core/tmp-dir!)]
+    (when-not (nil? cache)
+      (if cache
+        (do
+          (util/info "Turning Selmer cache ON\n")
+          (selmer.parser/cache-on!))
+        (do
+          (util/info "Turning Selmer cache OFF\n")
+          (selmer.parser/cache-off!))))
     (fn middleware [next-handler]
       (fn handler [fileset]
         (core/empty-dir! tmp)
@@ -55,7 +64,7 @@
               (when (not (s/starts-with? (.getName in-file) "_"))
                 (compile-selmer! in-file out-file context)
                 (util/info "• %s\n" (.getName out-file))))))
-          (-> fileset
-              (core/add-resource tmp)
-              core/commit!
-              next-handler)))))
+        (-> fileset
+            (core/add-resource tmp)
+            core/commit!
+            next-handler)))))


### PR DESCRIPTION
Clojure 1.9 validates that the require used in the ns form is a keyword (:require). Previous versions of Clojure weren't strict about this. This is a small fix to use the keyword :require so this task can be used with Clojure 1.9.